### PR TITLE
Faster field copying

### DIFF
--- a/lib/iris/fileformats/ff.py
+++ b/lib/iris/fileformats/ff.py
@@ -602,7 +602,14 @@ class FF2PP(object):
         for i_model_level in range(levels_count):
             # Make subsequent fields alike, but distinct.
             if i_model_level > 0:
-                field = field.copy()
+                new_field = type(field)()
+                for attr in field.__slots__:
+                    try:
+                        value = getattr(field, attr)
+                    except AttributeError:
+                        pass
+                    else:
+                        setattr(new_field, attr, value)
             # Provide the correct "model level" value.
             field.lblev = i_model_level
             # TODO: as LBC lookup headers cover multiple layers, they


### PR DESCRIPTION
This removes the overhead of field copying.

`iris.load()` timings for a file containing 40 cubes (t: 22, z: 38:, y: 192, x: 155)

| Code | Time to perform iris.load() |
| --- | --- |
| upstream/master | 6.2s (ignores vertical dimension; scaling by 38 gives 3m 48s) |
| pp-mo/lbc_levels | 4m 12s |
| This PR | 3m 19s |
