### PR TITLE
Extend point in cell

### DIFF
--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2013 - 2015, Met Office
+# (C) British Crown Copyright 2013 - 2016, Met Office
 #
 # This file is part of Iris.
 #

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -849,18 +849,20 @@ def regrid_weighted_curvilinear_to_rectilinear(src_cube, weights, grid_cube):
 
     """
     regrid_info = \
-        _regrid_weighted_curvilinear_to_rectilinear__calculate_regrid_info(
+        _regrid_weighted_curvilinear_to_rectilinear__prepare(
             src_cube, weights, grid_cube)
-    result = _regrid_weighted_curvilinear_to_rectilinear__perform_regrid(
+    result = _regrid_weighted_curvilinear_to_rectilinear__perform(
         src_cube, regrid_info)
     return result
 
 
-def _regrid_weighted_curvilinear_to_rectilinear__calculate_regrid_info(
+def _regrid_weighted_curvilinear_to_rectilinear__prepare(
         src_cube, weights, grid_cube):
     """
-    Check inputs and calculate the sparse info needed for the
-    'regrid_weighted_curvilinear_to_rectilinear' calculation.
+    First (setup) part of 'regrid_weighted_curvilinear_to_rectilinear'.
+
+    Check inputs and calculate the sparse regrid matrix and related info.
+    The 'regrid info' returned can be re-used over many 2d slices.
 
     """
     if src_cube.aux_factories:
@@ -1074,11 +1076,12 @@ def _regrid_weighted_curvilinear_to_rectilinear__calculate_regrid_info(
     return regrid_info
 
 
-def _regrid_weighted_curvilinear_to_rectilinear__perform_regrid(
+def _regrid_weighted_curvilinear_to_rectilinear__perform(
         src_cube, regrid_info):
     """
-    Perform actual regrid calculation for
-    'regrid_weighted_curvilinear_to_rectilinear'.
+    Second (regrid) part of 'regrid_weighted_curvilinear_to_rectilinear'.
+
+    Perform the prepared regrid calculation on a single 2d cube.
 
     """
     sparse_matrix, sum_weights, rows, grid_cube = regrid_info
@@ -1238,10 +1241,12 @@ class _CurvilinearRegridder(object):
             if regrid_info is None:
                 # Calculate the basic regrid info just once.
                 regrid_info = \
-                    _regrid_weighted_curvilinear_to_rectilinear__calculate_regrid_info(
+                    _regrid_weighted_curvilinear_to_rectilinear__prepare(
                         slice_cube, self.weights, self._target_cube)
-            result_slices.append(_regrid_weighted_curvilinear_to_rectilinear__perform_regrid(
-                slice_cube, regrid_info))
+            slice_result = \
+                _regrid_weighted_curvilinear_to_rectilinear__perform(
+                    slice_cube, regrid_info)
+            result_slices.append(slice_result)
         result = result_slices.merge_cube()
         return result
 

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -1095,7 +1095,6 @@ def _regrid_weighted_curvilinear_to_rectilinear__perform(
         # Zero any masked source points so they add nothing in output sums.
         if np.ma.is_masked(src_cube.data):
             mask = src_cube.data.mask
-            valid = ~mask
             data[mask] = 0.0
 
     # Calculate sum in each target cell, over contributions from each source
@@ -1105,10 +1104,13 @@ def _regrid_weighted_curvilinear_to_rectilinear__perform(
     # Create a template for the weighted mean result.
     weighted_mean = ma.masked_all(numerator.shape, dtype=numerator.dtype)
 
-    # Account for missing input data points.
+    # Account for any missing input data points.
     if np.ma.is_masked(src_cube.data):
         # Calculate a new 'sum_weights' to account for missing source points.
-        src_cell_validity_factors = sparse_diags(np.array(valid, dtype=int), 0)
+        valid_src_cells = ~mask.flat[:]
+        src_cell_validity_factors = sparse_diags(
+            np.array(valid_src_cells, dtype=int),
+            0)
         valid_weights = sparse_matrix * src_cell_validity_factors
         sum_weights = valid_weights.sum(axis=1)
         sum_weights = np.maximum(1, sum_weights).getA()

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -1231,13 +1231,12 @@ class _CurvilinearRegridder(object):
                              'source grid as this regridder.')
 
         # Call the regridder function.
-#        res = regrid_weighted_curvilinear_to_rectilinear(
-#            src, self.weights, self._target_cube)
-#        return res
         # This includes repeating over any non-XY dimensions, because the
         # underlying routine does not support this.
-        # Just for now, we will use cube.slices and merge to achieve this,
+        # FOR NOW: we will use cube.slices and merge to achieve this,
         # though that is not a terribly efficient method ...
+        # TODO: create a template result cube and paste data slices into it,
+        # which would be more efficient.
         result_slices = iris.cube.CubeList([])
         for slice_cube in src.slices(sx):
             if self._regrid_info is None:

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -1135,7 +1135,7 @@ class _CurvilinearRegridder(object):
     between a curvilinear source grid and a rectilinear target grid.
 
     """
-    def __init__(self, src_grid_cube, target_grid_cube, weights):
+    def __init__(self, src_grid_cube, target_grid_cube, weights=None):
         """
         Create a regridder for conversions between the source
         and target grids.
@@ -1146,10 +1146,14 @@ class _CurvilinearRegridder(object):
             The :class:`~iris.cube.Cube` providing the source grid.
         * tgt_grid_cube:
             The :class:`~iris.cube.Cube` providing the target grid.
+
+        Optional Args:
+
         * weights:
             A :class:`numpy.ndarray` instance that defines the weights
             for the grid cells of the source grid. Must have the same shape
             as the data of the source grid.
+            If unspecified, equal weighting is assumed.
 
         """
         # Validity checks.
@@ -1249,17 +1253,18 @@ class PointInCell(object):
     :meth:`iris.cube.Cube.regrid()`.
 
     """
-    def __init__(self, weights):
+    def __init__(self, weights=None):
         """
         Point-in-cell regridding scheme suitable for regridding over one
         or more orthogonal coordinates.
 
-        Args:
+        Optional Args:
 
         * weights:
             A :class:`numpy.ndarray` instance that defines the weights
             for the grid cells of the source grid. Must have the same shape
             as the data of the source grid.
+            If unspecified, equal weighting is assumed.
 
         """
         self.weights = weights

--- a/lib/iris/experimental/regrid.py
+++ b/lib/iris/experimental/regrid.py
@@ -1171,6 +1171,7 @@ class _CurvilinearRegridder(object):
         self._src_cube = src_grid_cube.copy()
         self._target_cube = target_grid_cube.copy()
         self.weights = weights
+        self._regrid_info = None
 
     @staticmethod
     def _get_horizontal_coord(cube, axis):
@@ -1237,17 +1238,16 @@ class _CurvilinearRegridder(object):
         # underlying routine does not support this.
         # Just for now, we will use cube.slices and merge to achieve this,
         # though that is not a terribly efficient method ...
-        regrid_info = None
         result_slices = iris.cube.CubeList([])
         for slice_cube in src.slices(sx):
-            if regrid_info is None:
+            if self._regrid_info is None:
                 # Calculate the basic regrid info just once.
-                regrid_info = \
+                self._regrid_info = \
                     _regrid_weighted_curvilinear_to_rectilinear__prepare(
                         slice_cube, self.weights, self._target_cube)
             slice_result = \
                 _regrid_weighted_curvilinear_to_rectilinear__perform(
-                    slice_cube, regrid_info)
+                    slice_cube, self._regrid_info)
             result_slices.append(slice_result)
         result = result_slices.merge_cube()
         return result

--- a/lib/iris/tests/unit/experimental/regrid/test__CurvilinearRegridder.py
+++ b/lib/iris/tests/unit/experimental/regrid/test__CurvilinearRegridder.py
@@ -166,9 +166,9 @@ class Test___call__(tests.IrisTest):
             src_grid, self.weights, target_grid)
         self.assertEqual(len(patch_operate.call_args_list), 2)
         self.assertEqual(
-             patch_operate.call_args_list,
-             [mock.call(src_grid, mock.sentinel.regrid_info),
-              mock.call(different_src_cube, mock.sentinel.regrid_info)])
+            patch_operate.call_args_list,
+            [mock.call(src_grid, mock.sentinel.regrid_info),
+             mock.call(different_src_cube, mock.sentinel.regrid_info)])
 
 
 @tests.skip_data


### PR DESCRIPTION
Removing restrictions on the routine underlying PointInCell usage, so we can use it for cross-coord-system regridding.

**==For reference only==** at this point
The target base commit here is a recent tip of scitools/iris, but this isn't ready to merge yet.
Still to-do at this stage : 
 * repeat over additional dimensions ("layers") to handle multidimensional inputs.
 * add testcases for new abilities
