### PR TITLE
Transplant code from, and remove dependency on, iris.experimental.fieldsfile

### DIFF
--- a/lib/iris/fileformats/pp.py
+++ b/lib/iris/fileformats/pp.py
@@ -2254,10 +2254,11 @@ def _load_cubes_variable_loader(filenames, callback, loading_function,
         # structured loading, the 'field' of rules processing is no longer a
         # PPField but a FieldCollation.
         pp_filter = None
+        # Make a loader object for the generic rules code.
         loader = iris.fileformats.rules.Loader(
             um_fast_load._basic_load_function,
             loading_function_kwargs,
-            um_fast_load._convert)
+            um_fast_load._convert_collation)
     else:
         loader = iris.fileformats.rules.Loader(
             loading_function, loading_function_kwargs or {},

--- a/lib/iris/fileformats/um/_fast_load_structured_fields.py
+++ b/lib/iris/fileformats/um/_fast_load_structured_fields.py
@@ -14,7 +14,14 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Iris.  If not, see <http://www.gnu.org/licenses/>.
-"""Code for fast loading of structured UM data."""
+"""
+Code for fast loading of structured UM data.
+
+This module defines which pp-field elements take part in structured loading,
+and provides creation of :class:`FieldCollation` objects from lists of
+:class:`iris.fileformats.pp.PPField`.
+
+"""
 
 from __future__ import (absolute_import, division, print_function)
 from six.moves import (filter, input, map, range, zip)  # noqa


### PR DESCRIPTION
Shamelessly steals from the existing experimental code, in order to remove the dependency on it.
Also reviewed, re-organised + re-commented as seemed good.

This PR is targetted against branch "structured_load_api"
 \- as was #28.

As a sneaky preview, I also merged the two + checked the extended tests all pass.
(well they did once I fixed the problem it revealed ...)
