### PR TITLE
Trajectory vectorise rebased (more tests)

### DIFF
--- a/lib/iris/analysis/_interpolate_private.py
+++ b/lib/iris/analysis/_interpolate_private.py
@@ -225,10 +225,7 @@ def _nearest_neighbour_indices_ndcoords(cube, sample_point, cache=None):
     point = []
     ok_coord_ids = set(map(id, cube.dim_coords + cube.aux_coords))
     for coord, value in sample_point:
-        if isinstance(coord, six.string_types):
-            coord = cube.coord(coord)
-        else:
-            coord = cube.coord(coord)
+        coord = cube.coord(coord)
         if id(coord) not in ok_coord_ids:
             msg = ('Invalid sample coordinate {!r}: derived coordinates are'
                    ' not allowed.'.format(coord.name()))

--- a/lib/iris/analysis/_interpolate_private.py
+++ b/lib/iris/analysis/_interpolate_private.py
@@ -198,7 +198,7 @@ def _nearest_neighbour_indices_ndcoords(cube, sample_points, cache=None):
     See documentation for :func:`iris.analysis.interpolate.nearest_neighbour_indices`.
 
     'sample_points' is of the form [[coord-or-coord-name, point-value(s)]*].
-    The numbers of all the point-values sequences must be equal.
+    The lengths of all the point-values sequences must be equal.
 
     This function is adapted for points sampling a multi-dimensional coord,
     and can currently only do nearest neighbour interpolation.

--- a/lib/iris/analysis/trajectory.py
+++ b/lib/iris/analysis/trajectory.py
@@ -298,9 +298,9 @@ def interpolate(cube, sample_points, method=None):
                 fancy_index = list(np.array(contents) - start_ind)
             else:
                 # Should really never happen, if _ndcoords is right.
-                msg = ('Error trajectory interpolation: point selection '
-                       'indices do not all have the same form.')
-                raise ValueError()
+                msg = ('Internal error in trajectory interpolation : point '
+                       'selection indices should all have the same form.')
+                raise ValueError(msg)
 
             fancy_source_indices.append(fancy_index)
             region_slices.append(region_slice)

--- a/lib/iris/analysis/trajectory.py
+++ b/lib/iris/analysis/trajectory.py
@@ -249,30 +249,34 @@ def interpolate(cube, sample_points, method=None):
             method = "nearest"
             break
 
-    # Use a cache with _nearest_neighbour_indices_ndcoords()
-    cache = {}
-
-    for i in range(trajectory_size):
-        point = [(coord, values[i]) for coord, values in sample_points]
-
-        if method in ["linear", None]:
+    if method in ["linear", None]:
+        for i in range(trajectory_size):
+            point = [(coord, values[i]) for coord, values in sample_points]
             column = linear_regrid(cube, point)
             new_cube.data[..., i] = column.data
-        elif method == "nearest":
-            column_index = _nearest_neighbour_indices_ndcoords(cube, point,
-                                                               cache=cache)
+            # Fill in the empty squashed (non derived) coords.
+            for column_coord in column.dim_coords + column.aux_coords:
+                src_dims = cube.coord_dims(column_coord)
+                if not squish_my_dims.isdisjoint(src_dims):
+                    if len(column_coord.points) != 1:
+                        raise Exception("Expected to find exactly one point. Found %d" % len(column_coord.points))
+                    new_cube.coord(column_coord.name()).points[i] = column_coord.points[0]
+
+    elif method == "nearest":
+        # Use a cache with _nearest_neighbour_indices_ndcoords()
+        cache = {}
+        for i in range(trajectory_size):
+            point = [(coord, values[i]) for coord, values in sample_points]
+            column_index = _nearest_neighbour_indices_ndcoords(cube, point, cache=cache)
             column = cube[column_index]
             new_cube.data[..., i] = column.data
-
-        # Fill in the empty squashed (non derived) coords.
-        for column_coord in column.dim_coords + column.aux_coords:
-            src_dims = cube.coord_dims(column_coord)
-            if not squish_my_dims.isdisjoint(src_dims):
-                if len(column_coord.points) != 1:
-                    raise Exception("Expected to find exactly one point. "
-                                    "Found %d" % len(column_coord.points))
-                new_cube.coord(column_coord.name()).points[i] = \
-                    column_coord.points[0]
+            # Fill in the empty squashed (non derived) coords.
+            for column_coord in column.dim_coords + column.aux_coords:
+                src_dims = cube.coord_dims(column_coord)
+                if not squish_my_dims.isdisjoint(src_dims):
+                    if len(column_coord.points) != 1:
+                        raise Exception("Expected to find exactly one point. Found %d" % len(column_coord.points))
+                    new_cube.coord(column_coord.name()).points[i] = column_coord.points[0]
 
     return new_cube
 

--- a/lib/iris/analysis/trajectory.py
+++ b/lib/iris/analysis/trajectory.py
@@ -267,16 +267,17 @@ def interpolate(cube, sample_points, method=None):
         cache = {}
         for i in range(trajectory_size):
             point = [(coord, values[i]) for coord, values in sample_points]
-            column_index = _nearest_neighbour_indices_ndcoords(cube, point, cache=cache)
-            column = cube[column_index]
-            new_cube.data[..., i] = column.data
-            # Fill in the empty squashed (non derived) coords.
-            for column_coord in column.dim_coords + column.aux_coords:
-                src_dims = cube.coord_dims(column_coord)
-                if not squish_my_dims.isdisjoint(src_dims):
-                    if len(column_coord.points) != 1:
-                        raise Exception("Expected to find exactly one point. Found %d" % len(column_coord.points))
-                    new_cube.coord(column_coord.name()).points[i] = column_coord.points[0]
+            column_indexes = _nearest_neighbour_indices_ndcoords(cube, point, cache=cache)
+            for column_index in column_indexes:
+                column = cube[column_index]
+                new_cube.data[..., i] = column.data
+                # Fill in the empty squashed (non derived) coords.
+                for column_coord in column.dim_coords + column.aux_coords:
+                    src_dims = cube.coord_dims(column_coord)
+                    if not squish_my_dims.isdisjoint(src_dims):
+                        if len(column_coord.points) != 1:
+                            raise Exception("Expected to find exactly one point. Found %d" % len(column_coord.points))
+                        new_cube.coord(column_coord.name()).points[i] = column_coord.points[0]
 
     return new_cube
 

--- a/lib/iris/analysis/trajectory.py
+++ b/lib/iris/analysis/trajectory.py
@@ -259,8 +259,10 @@ def interpolate(cube, sample_points, method=None):
                 src_dims = cube.coord_dims(column_coord)
                 if not squish_my_dims.isdisjoint(src_dims):
                     if len(column_coord.points) != 1:
-                        raise Exception("Expected to find exactly one point. Found %d" % len(column_coord.points))
-                    new_cube.coord(column_coord.name()).points[i] = column_coord.points[0]
+                        msg = "Expected to find exactly one point. Found {}."
+                        raise Exception(msg.format(column_coord.points))
+                    new_cube.coord(column_coord.name()).points[i] = \
+                        column_coord.points[0]
 
     elif method == "nearest":
         # Use a cache with _nearest_neighbour_indices_ndcoords()

--- a/lib/iris/tests/integration/test_trajectory.py
+++ b/lib/iris/tests/integration/test_trajectory.py
@@ -196,6 +196,8 @@ class TestTriPolar(tests.IrisTest):
         test_cube = self.cube
         # Use just one 2d layer, just to be faster.
         test_cube = test_cube[0][0]
+        # Fetch all the data, so we can control the fill value.
+        test_cube.data
         # Fix the fill value of the data to zero, just so that we get the same
         # result under numpy < 1.11 as with 1.11.
         # NOTE: numpy<1.11 *used* to assign missing data points into an

--- a/lib/iris/tests/integration/test_trajectory.py
+++ b/lib/iris/tests/integration/test_trajectory.py
@@ -196,8 +196,6 @@ class TestTriPolar(tests.IrisTest):
         test_cube = self.cube
         # Use just one 2d layer, just to be faster.
         test_cube = test_cube[0][0]
-        # Fetch all the data, so we can control the fill value.
-        test_cube.data
         # Fix the fill value of the data to zero, just so that we get the same
         # result under numpy < 1.11 as with 1.11.
         # NOTE: numpy<1.11 *used* to assign missing data points into an

--- a/lib/iris/tests/unit/analysis/interpolate_private/test__nearest_neighbour_indices_ndcoords.py
+++ b/lib/iris/tests/unit/analysis/interpolate_private/test__nearest_neighbour_indices_ndcoords.py
@@ -46,7 +46,17 @@ class Test2d(tests.IrisTest):
         cube.add_dim_coord(co_x, 1)
         sample_point = [('x', 2.8), ('y', 18.5)]
         result = nn_ndinds(cube, sample_point)
-        self.assertEqual(result, (1, 2))
+        self.assertEqual(result, [(1, 2)])
+
+    def test_nonlatlon_multiple_2d(self):
+        co_y = DimCoord([10.0, 20.0], long_name='y')
+        co_x = DimCoord([1.0, 2.0, 3.0], long_name='x')
+        cube = Cube(np.zeros((2, 3)))
+        cube.add_dim_coord(co_y, 0)
+        cube.add_dim_coord(co_x, 1)
+        sample_points = [('x', [2.8, -350.0, 1.7]), ('y', [18.5, 8.7, 12.2])]
+        result = nn_ndinds(cube, sample_points)
+        self.assertEqual(result, [(1, 2), (0, 0), (0, 1)])
 
     def test_latlon_simple_2d(self):
         co_y = DimCoord([10.0, 20.0],
@@ -58,7 +68,21 @@ class Test2d(tests.IrisTest):
         cube.add_dim_coord(co_x, 1)
         sample_point = [('longitude', 2.8), ('latitude', 18.5)]
         result = nn_ndinds(cube, sample_point)
-        self.assertEqual(result, (1, 2))
+        self.assertEqual(result, [(1, 2)])
+
+    def test_latlon_multiple_2d(self):
+        co_y = DimCoord([10.0, 20.0],
+                        standard_name='latitude', units='degrees')
+        co_x = DimCoord([1.0, 2.0, 3.0],
+                        standard_name='longitude', units='degrees')
+        cube = Cube(np.zeros((2, 3)))
+        cube.add_dim_coord(co_y, 0)
+        cube.add_dim_coord(co_x, 1)
+        sample_points = [('longitude', [2.8, -350.0, 1.7]),
+                         ('latitude', [18.5, 8.7, 12.2])]
+        result = nn_ndinds(cube, sample_points)
+        # Note slight difference from non-latlon version.
+        self.assertEqual(result, [(1, 2), (0, 2), (0, 1)])
 
 
 class Test1d(tests.IrisTest):
@@ -70,7 +94,7 @@ class Test1d(tests.IrisTest):
         cube.add_aux_coord(co_x, 0)
         sample_point = [('x', 2.8), ('y', 18.5)]
         result = nn_ndinds(cube, sample_point)
-        self.assertEqual(result, (5,))
+        self.assertEqual(result, [(5,)])
 
     def test_latlon_simple_1d(self):
         cube = Cube([11.0, 12.0, 13.0, 21.0, 22.0, 23.0])
@@ -82,7 +106,7 @@ class Test1d(tests.IrisTest):
         cube.add_aux_coord(co_x, 0)
         sample_point = [('longitude', 2.8), ('latitude', 18.5)]
         result = nn_ndinds(cube, sample_point)
-        self.assertEqual(result, (5,))
+        self.assertEqual(result, [(5,)])
 
 
 class TestApiExtras(tests.IrisTest):
@@ -96,7 +120,7 @@ class TestApiExtras(tests.IrisTest):
         cube.add_dim_coord(co_x, 1)
         sample_point = [('x', 2.8)]
         result = nn_ndinds(cube, sample_point)
-        self.assertEqual(result, (slice(None), 2))
+        self.assertEqual(result, [(slice(None), 2)])
 
     def test_no_x_dim(self):
         # Operate in Y only, returned slice should be [iy, :].
@@ -107,7 +131,7 @@ class TestApiExtras(tests.IrisTest):
         cube.add_dim_coord(co_x, 1)
         sample_point = [('y', 18.5)]
         result = nn_ndinds(cube, sample_point)
-        self.assertEqual(result, (1, slice(None)))
+        self.assertEqual(result, [(1, slice(None))])
 
     def test_sample_dictionary(self):
         # Pass sample_point arg as a dictionary: this usage mode is deprecated.
@@ -120,7 +144,7 @@ class TestApiExtras(tests.IrisTest):
         warn_call = self.patch(
             'iris.analysis._interpolate_private.warn_deprecated')
         result = nn_ndinds(cube, sample_point)
-        self.assertEqual(result, (1, 2))
+        self.assertEqual(result, [(1, 2)])
         self.assertEqual(warn_call.call_count, 1)
         self.assertIn('dictionary to specify points is deprecated',
                       warn_call.call_args[0][0])
@@ -139,7 +163,7 @@ class TestLatlon(tests.IrisTest):
     def _check_latlon_1d(self, lats, lons, sample_point, expect):
         cube = self._testcube_latlon_1d(lats, lons)
         result = nn_ndinds(cube, sample_point)
-        self.assertEqual(result, (expect,))
+        self.assertEqual(result, [(expect,)])
 
     def test_lat_scaling(self):
         # Check that (88, 25) is closer to (88, 0) than to (87, 25)
@@ -158,7 +182,7 @@ class TestLatlon(tests.IrisTest):
         cube.coord('longitude').rename('x_longitude_x')
         sample_point = [('y_latitude_y', 88), ('x_longitude_x', 25)]
         result = nn_ndinds(cube, sample_point)
-        self.assertEqual(result, (0,))
+        self.assertEqual(result, [(0,)])
 
     def test_alternate_nonlatlon_names_different(self):
         # Check that (88, 25) is **NOT** closer to (88, 0) than to (87, 25)
@@ -169,7 +193,7 @@ class TestLatlon(tests.IrisTest):
         cube.coord('longitude').rename('x')
         sample_point = [('y', 88), ('x', 25)]
         result = nn_ndinds(cube, sample_point)
-        self.assertEqual(result, (1,))
+        self.assertEqual(result, [(1,)])
 
     def test_lons_wrap_359_0(self):
         # Check that (0, 359) is closer to (0, 0) than to (0, 350)

--- a/lib/iris/tests/unit/analysis/trajectory/test_interpolate.py
+++ b/lib/iris/tests/unit/analysis/trajectory/test_interpolate.py
@@ -161,8 +161,9 @@ class TestNearest(tests.IrisTest):
                                      [211, 212, 213, 214]],
                                     long_name='aux_0x'),
                            (0, 2))
-        msg = 'Expected to find exactly one point.*Found 2'
-        with self.assertRaisesRegexp(Exception, msg):
+        msg = ('Coord aux_0x at one x-y position has the shape.*'
+               'instead of being a single point')
+        with self.assertRaisesRegexp(ValueError, msg):
             interpolate(cube, self.single_sample_point, method='nearest')
 
     def test_metadata(self):


### PR DESCRIPTION
Shows new-method trajectory interpolation passing the enhanced tests from the 'trajectory_regrid_tests' branch.
Means we can merge this on top when that is merged (subject to rebasing on changes)

**DO NOT MERGE**
Wanted for proof-of-principle only.
When [iris#2258 "Trajectory regrid tests"](https://github.com/SciTools/iris/pull/2258) is accepted...
 * I will rebase the Iris PR  [https://github.com/SciTools/iris/pull/2252 "Trajectory vectorise"](https://github.com/SciTools/iris/pull/2258) and incorporate the additions shown here 
 * Then we close this + use the Iris PR instead.