### PR TITLE
Cc syntax

### DIFF
--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -128,7 +128,7 @@ __version__ = '1.12.0-DEV'
 __all__ = ['load', 'load_cube', 'load_cubes', 'load_raw',
            'save', 'Constraint', 'AttributeConstraint', 'sample_data_path',
            'site_configuration', 'Future', 'FUTURE',
-           'IrisDeprecation']
+           'IrisDeprecation', 'COORD_CONSTRAINER']
 
 
 # When required, log the usage of Iris.

--- a/lib/iris/__init__.py
+++ b/lib/iris/__init__.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -138,6 +138,7 @@ if iris.config.IMPORT_LOGGER:
 
 Constraint = iris._constraints.Constraint
 AttributeConstraint = iris._constraints.AttributeConstraint
+COORD_CONSTRAINER = iris._constraints.CoordConstraintHelper()
 
 
 class Future(threading.local):

--- a/lib/iris/_constraints.py
+++ b/lib/iris/_constraints.py
@@ -514,7 +514,7 @@ class CoordConstraintHelper(object):
         >>>
         >>> path = get_data_path(('PP', 'simple_pp', 'global.pp'))
         >>> cube = iris.load_cube(path)
-        >>> region = cube.cut(longitude=CC[-6:30], latitude=CC[51:78])
+        >>> region = cube.sel(longitude=CC[-6:30], latitude=CC[51:78])
         >>> print region.shape
         (11, 9)
 

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -1,4 +1,4 @@
-# (C) British Crown Copyright 2010 - 2016, Met Office
+# (C) British Crown Copyright 2010 - 2017, Met Office
 #
 # This file is part of Iris.
 #
@@ -2310,6 +2310,9 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         # Cast the constraint into a proper constraint if it is not so already
         constraint = iris._constraints.as_constraint(constraint)
         return constraint.extract(self)
+
+    def cut(self, *args, **kwargs):
+        return self.extract(iris._constraints.Constraint(*args, **kwargs))
 
     def intersection(self, *args, **kwargs):
         """

--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -2311,7 +2311,21 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         constraint = iris._constraints.as_constraint(constraint)
         return constraint.extract(self)
 
-    def cut(self, *args, **kwargs):
+    def sel(self, *args, **kwargs):
+        """
+        Build a constraint and extract with it.
+
+        Equivalent to ``self.extract(Constraint(*args, **kwargs))``.
+
+        Designed to provide a neater syntax for coordinate constraints, along
+        with :data:`~iris.COORD_CONSTRAINER`.
+
+        .. for example:
+            >>> cube.sel(longitude=CC[0:180], latitude=CC[0:45,'[]'])
+
+        TODO: proper docs here.
+
+        """
         return self.extract(iris._constraints.Constraint(*args, **kwargs))
 
     def intersection(self, *args, **kwargs):

--- a/lib/iris/tests/integration/test_coord_constrainer.py
+++ b/lib/iris/tests/integration/test_coord_constrainer.py
@@ -1,0 +1,141 @@
+# (C) British Crown Copyright 2017, Met Office
+#
+# This file is part of Iris.
+#
+# Iris is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Iris is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Iris.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Integration tests for :class:`iris._constraints.CoordConstraintHelper`
+
+Also exercising the new :meth:`cube.cut`.
+
+"""
+
+from __future__ import (absolute_import, division, print_function)
+from six.moves import (filter, input, map, range, zip)  # noqa
+
+# Import iris.tests first so that some things can be initialised before
+# importing anything else.
+import iris.tests as tests
+
+import numpy as np
+
+import iris
+from iris.tests import get_data_path
+from iris import Constraint, COORD_CONSTRAINER as CC
+
+
+class Test(tests.IrisTest):
+    def show(self, cube, comment,
+             show_cube=False, show_coords=True, int_coords=True,
+             show_lats=True, show_lons=True):
+        print()
+        print(comment)
+        if show_cube:
+            print('cube = \n', cube)
+        if show_coords:
+            lons = cube.coord('longitude').points
+            lats = cube.coord('latitude').points
+            if int_coords:
+                lons = lons.astype(int)
+                lats = lats.astype(int)
+            if show_lons:
+                print('lons = ', lons)
+            if show_lats:
+                print('lats = ', lats)
+
+    def test(self):
+        # A few tests to exercise the new stuff -- not proper tests, yet.
+        path = get_data_path(('PP', 'simple_pp', 'global.pp'))
+        cube = iris.load_cube(path)
+
+        cube = cube[::4, ::4]
+        self.show(cube, 'original:', show_cube=True, int_coords=False)
+
+        msg = """\
+test cube.extract :
+   = cube.extract(Constraint(longitude=lambda cell: cell > 120.0,
+                             latitude=lambda cell: -10 <= cell < 40))
+"""
+        subcube = cube.extract(
+            Constraint(longitude=lambda cell: cell > 120.0,
+                       latitude=lambda cell: -10 <= cell < 40))
+        self.show(subcube, msg)
+
+        #
+        # Test the equivalent using the new facilities.
+        #
+        msg = """\
+print 'CC version'
+  = cube.cut(longitude=CC > 120.0, latitude=CC(-10, 40))
+"""
+        subcube_cc = cube.cut(longitude=CC > 120.0, latitude=CC(-10, 40))
+        self.show(subcube_cc, msg)
+        same = subcube_cc == subcube
+        print('?same? : ', same)
+        self.assertTrue(same)
+
+        subcube = cube.extract(Constraint(longitude=CC.near(130)))
+        self.show(subcube, 'lons=CC.near(130)', show_lats=False)
+
+        msg = 'cut(lon=CC > 300, lat=CC.between(-10,40)) :'
+        subcube = cube.cut(longitude=CC > 300, latitude=CC.between(-10, 40))
+        self.show(subcube, msg)
+        self.assertArrayAllClose(subcube.coord('longitude').points,
+                                 [315, 330, 345], atol=0.01)
+        self.assertArrayAllClose(subcube.coord('latitude').points,
+                                 [30, 20, 10,  0, -10], atol=0.01)
+
+        msg = 'cut(lat=CC(-10,40)) :'
+        subcube = cube.cut(latitude=CC(-10, 40))
+        self.show(subcube, msg, show_lons=False)
+        self.assertArrayAllClose(subcube.coord('latitude').points,
+                                 [30, 20, 10,  0, -10], atol=0.01)
+
+        subcube = cube.cut(longitude=164.99995422)
+        msg = 'cut(lon=164.99995422):'
+        self.show(subcube, msg, show_cube=True, show_coords=False)
+        self.assertIsNone(subcube)
+
+        msg = 'cut(lon=CC(165)):'
+        subcube = cube.cut(longitude=CC(165))
+        self.show(subcube, msg, show_lats=False)
+        self.assertArrayAllClose(subcube.coord('longitude').points,
+                                 [164.999954])
+
+        msg = 'cut(lon=CC ^ 165, lat=CC ^ 100):'
+        subcube = cube.cut(longitude=CC ^ 165, latitude=CC ^ 100)
+        self.show(subcube, msg)
+        self.assertArrayAllClose(subcube.coord('longitude').points,
+                                 [165], atol=0.01)
+        self.assertArrayAllClose(subcube.coord('latitude').points,
+                                 [90], atol=0.01)
+
+        msg = 'cut(lon=CC >= 165):'
+        subcube = cube.cut(longitude=CC >= 165)
+        self.show(subcube, msg, show_lats=False)
+        self.assertArrayAllClose(subcube.coord('longitude').points,
+                                 np.arange(180, 360, 15), atol=0.01)
+
+        msg = 'cut(lon=CC < 165):'
+        subcube = cube.cut(longitude=CC < 165)
+        self.show(subcube, msg, show_lats=False)
+        self.assertArrayAllClose(subcube.coord('longitude').points,
+                                 np.arange(0, 165.1, 15), atol=0.01)
+        # N.B. last point is at ~165, because it is a bit under the value.
+        self.assertArrayAllClose(subcube.coord('longitude').points[-1],
+                                 [164.999954])
+
+
+if __name__ == '__main__':
+    tests.main()

--- a/lib/iris/tests/integration/test_coord_constrainer.py
+++ b/lib/iris/tests/integration/test_coord_constrainer.py
@@ -56,6 +56,7 @@ class Test(tests.IrisTest):
             if show_lats:
                 print('lats = ', lats)
 
+    @tests.skip_data
     def test(self):
         # A few tests to exercise the new stuff -- not proper tests, yet.
         path = get_data_path(('PP', 'simple_pp', 'global.pp'))

--- a/lib/iris/tests/integration/test_coord_constrainer.py
+++ b/lib/iris/tests/integration/test_coord_constrainer.py
@@ -79,9 +79,9 @@ test cube.extract :
         #
         msg = """\
 print 'CC version'
-  = cube.cut(longitude=CC > 120.0, latitude=CC(-10, 40))
+  = cube.cut(longitude=CC > 120.0, latitude=CC[-10:40])
 """
-        subcube_cc = cube.cut(longitude=CC > 120.0, latitude=CC(-10, 40))
+        subcube_cc = cube.cut(longitude=CC > 120.0, latitude=CC[-10:40])
         self.show(subcube_cc, msg)
         same = subcube_cc == subcube
         print('?same? : ', same)
@@ -105,8 +105,8 @@ print 'CC version'
         self.assertArrayAllClose(subcube.coord('latitude').points,
                                  [30, 20, 10,  0, -10], atol=0.01)
 
-        msg = 'cut(lat=CC(-10,40)) :'
-        subcube = cube.cut(latitude=CC(-10, 40))
+        msg = 'cut(lat=CC[-10:40]) :'
+        subcube = cube.cut(latitude=CC[-10:40])
         self.show(subcube, msg, show_lons=False)
         self.assertArrayAllClose(subcube.coord('latitude').points,
                                  [30, 20, 10,  0, -10], atol=0.01)

--- a/lib/iris/tests/integration/test_coord_constrainer.py
+++ b/lib/iris/tests/integration/test_coord_constrainer.py
@@ -31,6 +31,8 @@ import iris.tests as tests
 import numpy as np
 
 import iris
+from iris.cube import Cube
+from iris.coords import DimCoord
 from iris.tests import get_data_path
 from iris import Constraint, COORD_CONSTRAINER as CC
 
@@ -96,6 +98,13 @@ print 'CC version'
         self.assertArrayAllClose(subcube.coord('latitude').points,
                                  [30, 20, 10,  0, -10], atol=0.01)
 
+        # Test the indexing form of the range operator.
+        msg = 'cut(lat=CC[-10:40]) :'
+        subcube = cube.cut(longitude=CC > 300, latitude=CC[-10:40])
+        self.show(subcube, msg, show_lons=False)
+        self.assertArrayAllClose(subcube.coord('latitude').points,
+                                 [30, 20, 10,  0, -10], atol=0.01)
+
         msg = 'cut(lat=CC(-10,40)) :'
         subcube = cube.cut(latitude=CC(-10, 40))
         self.show(subcube, msg, show_lons=False)
@@ -135,6 +144,42 @@ print 'CC version'
         # N.B. last point is at ~165, because it is a bit under the value.
         self.assertArrayAllClose(subcube.coord('longitude').points[-1],
                                  [164.999954])
+
+    def test_index_range(self):
+        # Test precise forms of range specifier for indexing.
+        cube = Cube(np.arange(10))
+        cube.add_dim_coord(DimCoord(np.arange(10, dtype=int), 'longitude'), 0)
+        cube.add_aux_coord(DimCoord([0], 'latitude'))
+
+        msg = '0..9, cut(lons=[3:7]) :'
+        subcube = cube.cut(longitude=CC[3:7])
+        self.show(subcube, msg, show_lats=False)
+        self.assertArrayEqual(subcube.coord('longitude').points,
+                              [3, 4, 5, 6])
+
+        msg = '0..9, cut(lons=[3:7], "[)") :'
+        subcube = cube.cut(longitude=CC[3:7, "[)"])
+        self.show(subcube, msg, show_lats=False)
+        self.assertArrayEqual(subcube.coord('longitude').points,
+                              [3, 4, 5, 6])
+
+        msg = '0..9, cut(lons=[3:7, "()"]) :'
+        subcube = cube.cut(longitude=CC[3:7, "()"])
+        self.show(subcube, msg, show_lats=False)
+        self.assertArrayEqual(subcube.coord('longitude').points,
+                              [4, 5, 6])
+
+        msg = '0..9, cut(lons=[3:7, "[]"]) :'
+        subcube = cube.cut(longitude=CC[3:7, "[]"])
+        self.show(subcube, msg, show_lats=False)
+        self.assertArrayEqual(subcube.coord('longitude').points,
+                              [3, 4, 5, 6, 7])
+
+        msg = '0..9, cut(lons=[3:7, "(]"]) :'
+        subcube = cube.cut(longitude=CC[3:7, "(]"])
+        self.show(subcube, msg, show_lats=False)
+        self.assertArrayEqual(subcube.coord('longitude').points,
+                              [4, 5, 6, 7])
 
 
 if __name__ == '__main__':

--- a/lib/iris/tests/integration/test_coord_constrainer.py
+++ b/lib/iris/tests/integration/test_coord_constrainer.py
@@ -17,7 +17,7 @@
 """
 Integration tests for :class:`iris._constraints.CoordConstraintHelper`
 
-Also exercising the new :meth:`cube.cut`.
+Also exercising the new :meth:`cube.sel`.
 
 """
 
@@ -78,10 +78,10 @@ test cube.extract :
         # Test the equivalent using the new facilities.
         #
         msg = """\
-print 'CC version'
-  = cube.cut(longitude=CC > 120.0, latitude=CC[-10:40])
+print 'CC+sel version'
+  = cube.sel(longitude=CC > 120.0, latitude=CC[-10:40])
 """
-        subcube_cc = cube.cut(longitude=CC > 120.0, latitude=CC[-10:40])
+        subcube_cc = cube.sel(longitude=CC > 120.0, latitude=CC[-10:40])
         self.show(subcube_cc, msg)
         same = subcube_cc == subcube
         print('?same? : ', same)
@@ -90,8 +90,8 @@ print 'CC version'
         subcube = cube.extract(Constraint(longitude=CC.near(130)))
         self.show(subcube, 'lons=CC.near(130)', show_lats=False)
 
-        msg = 'cut(lon=CC > 300, lat=CC.between(-10,40)) :'
-        subcube = cube.cut(longitude=CC > 300, latitude=CC.between(-10, 40))
+        msg = 'sel(lons=CC > 300, lats=CC.between(-10,40)) :'
+        subcube = cube.sel(longitude=CC > 300, latitude=CC.between(-10, 40))
         self.show(subcube, msg)
         self.assertArrayAllClose(subcube.coord('longitude').points,
                                  [315, 330, 345], atol=0.01)
@@ -99,45 +99,45 @@ print 'CC version'
                                  [30, 20, 10,  0, -10], atol=0.01)
 
         # Test the indexing form of the range operator.
-        msg = 'cut(lat=CC[-10:40]) :'
-        subcube = cube.cut(longitude=CC > 300, latitude=CC[-10:40])
+        msg = 'sel(lats=CC[-10:40]) :'
+        subcube = cube.sel(longitude=CC > 300, latitude=CC[-10:40])
         self.show(subcube, msg, show_lons=False)
         self.assertArrayAllClose(subcube.coord('latitude').points,
                                  [30, 20, 10,  0, -10], atol=0.01)
 
-        msg = 'cut(lat=CC[-10:40]) :'
-        subcube = cube.cut(latitude=CC[-10:40])
+        msg = 'sel(lats=CC[-10:40]) :'
+        subcube = cube.sel(latitude=CC[-10:40])
         self.show(subcube, msg, show_lons=False)
         self.assertArrayAllClose(subcube.coord('latitude').points,
                                  [30, 20, 10,  0, -10], atol=0.01)
 
-        subcube = cube.cut(longitude=164.99995422)
-        msg = 'cut(lon=164.99995422):'
+        subcube = cube.sel(longitude=164.99995422)
+        msg = 'sel(lons=164.99995422):'
         self.show(subcube, msg, show_cube=True, show_coords=False)
         self.assertIsNone(subcube)
 
-        msg = 'cut(lon=CC(165)):'
-        subcube = cube.cut(longitude=CC(165))
+        msg = 'sel(lons=CC(165)):'
+        subcube = cube.sel(longitude=CC(165))
         self.show(subcube, msg, show_lats=False)
         self.assertArrayAllClose(subcube.coord('longitude').points,
                                  [164.999954])
 
-        msg = 'cut(lon=CC ^ 165, lat=CC ^ 100):'
-        subcube = cube.cut(longitude=CC ^ 165, latitude=CC ^ 100)
+        msg = 'sel(lons=CC ^ 165, lats=CC ^ 100):'
+        subcube = cube.sel(longitude=CC ^ 165, latitude=CC ^ 100)
         self.show(subcube, msg)
         self.assertArrayAllClose(subcube.coord('longitude').points,
                                  [165], atol=0.01)
         self.assertArrayAllClose(subcube.coord('latitude').points,
                                  [90], atol=0.01)
 
-        msg = 'cut(lon=CC >= 165):'
-        subcube = cube.cut(longitude=CC >= 165)
+        msg = 'sel(lons=CC >= 165):'
+        subcube = cube.sel(longitude=CC >= 165)
         self.show(subcube, msg, show_lats=False)
         self.assertArrayAllClose(subcube.coord('longitude').points,
                                  np.arange(180, 360, 15), atol=0.01)
 
-        msg = 'cut(lon=CC < 165):'
-        subcube = cube.cut(longitude=CC < 165)
+        msg = 'sel(lons=CC < 165):'
+        subcube = cube.sel(longitude=CC < 165)
         self.show(subcube, msg, show_lats=False)
         self.assertArrayAllClose(subcube.coord('longitude').points,
                                  np.arange(0, 165.1, 15), atol=0.01)
@@ -151,32 +151,32 @@ print 'CC version'
         cube.add_dim_coord(DimCoord(np.arange(10, dtype=int), 'longitude'), 0)
         cube.add_aux_coord(DimCoord([0], 'latitude'))
 
-        msg = '0..9, cut(lons=[3:7]) :'
-        subcube = cube.cut(longitude=CC[3:7])
+        msg = '0..9, sel(lons=[3:7]) :'
+        subcube = cube.sel(longitude=CC[3:7])
         self.show(subcube, msg, show_lats=False)
         self.assertArrayEqual(subcube.coord('longitude').points,
                               [3, 4, 5, 6])
 
-        msg = '0..9, cut(lons=[3:7], "[)") :'
-        subcube = cube.cut(longitude=CC[3:7, "[)"])
+        msg = '0..9, sel(lons=[3:7, "[)"]) :'
+        subcube = cube.sel(longitude=CC[3:7, "[)"])
         self.show(subcube, msg, show_lats=False)
         self.assertArrayEqual(subcube.coord('longitude').points,
                               [3, 4, 5, 6])
 
-        msg = '0..9, cut(lons=[3:7, "()"]) :'
-        subcube = cube.cut(longitude=CC[3:7, "()"])
+        msg = '0..9, sel(lons=[3:7, "()"]) :'
+        subcube = cube.sel(longitude=CC[3:7, "()"])
         self.show(subcube, msg, show_lats=False)
         self.assertArrayEqual(subcube.coord('longitude').points,
                               [4, 5, 6])
 
-        msg = '0..9, cut(lons=[3:7, "[]"]) :'
-        subcube = cube.cut(longitude=CC[3:7, "[]"])
+        msg = '0..9, sel(lons=[3:7, "[]"]) :'
+        subcube = cube.sel(longitude=CC[3:7, "[]"])
         self.show(subcube, msg, show_lats=False)
         self.assertArrayEqual(subcube.coord('longitude').points,
                               [3, 4, 5, 6, 7])
 
-        msg = '0..9, cut(lons=[3:7, "(]"]) :'
-        subcube = cube.cut(longitude=CC[3:7, "(]"])
+        msg = '0..9, sel(lons=[3:7, "(]"]) :'
+        subcube = cube.sel(longitude=CC[3:7, "(]"])
         self.show(subcube, msg, show_lats=False)
         self.assertArrayEqual(subcube.coord('longitude').points,
                               [4, 5, 6, 7])


### PR DESCRIPTION
**PLEASE DO NOT MERGE**

Some ideas for neater cube selection syntax ***via existing constraint mechanisms***.
The key bit is to have a 'helper' object with special functions that translate common Python syntax into useful cell-functions (like lambdas) for making constraints.  A bit like numpy ogrid/mgrid.

Crib sheet of features:
  * ```cube.sel(**keys)``` is added as a neat shorthand for ```cube.extract(Constraint(**keys))```.
  * ```CC > x``` and similar ```<```, ```<=```, ```>```, ```>=```
    * perform one-sided range constraints : e.g. ```cube.sel(longitude=CC < 47.5)```
  * ```CC[from:to]``` and ```CC[from:to, range_type='[)']```
    * perform two-sided range constraints : e.g. ```cube.sel(latitude=CC[-15.7:35.2])```
    * also provided as : ```CC.between(ge=None, lt=None, le=None, gt=None)```
  * ```CC(x)``` 
    * select only nearest coordinate point to the given value : e.g. ```cube.sel(longitude=CC(13.7))```
    * note how this differs from ```(x=3.773)```, which has a problem with exact matching of floats
    * also provided as : ```CC.nearest(x)```
    * also provided as : ```CC ^ x```
      * (not sure about this syntax; could use '=='; nothing really matches the intent)

'sel' also allows combinations, 
e.g. ```cube.sel(y=CC(32.5), x=CC[0:75])```