### PR TITLE
No set dtype

### DIFF
--- a/lib/iris/cube.py
+++ b/lib/iris/cube.py
@@ -754,7 +754,9 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
         # We need to set the dtype before the fill_value,
         # as the fill_value is checked against self.dtype.
         self._realisation_dtype = None
-        if self.has_lazy_data() and dtype is not None:
+        if (self.has_lazy_data() and
+                dtype is not None and
+                dtype != self.dtype):
             # Record 'real' dtype for lazy data which represents masked ints.
             dtype = np.dtype(dtype)
             if dtype.kind not in ('i', 'u'):
@@ -824,8 +826,10 @@ bound=(1994-12-01 00:00:00, 1998-12-01 00:00:00)
                     raise TypeError('Invalid/incomplete metadata')
         for name in CubeMetadata._fields:
             alias = name
-            if name in ['dtype', 'fill_value']:
-                alias = '_{}'.format(name)
+            if name == 'dtype':
+                alias = '_realisation_dtype'
+            elif name == 'fill_value':
+                alias = '_fill_value'
             setattr(self, alias, getattr(value, name))
 
     def is_compatible(self, other, ignore=None):

--- a/lib/iris/tests/integration/fast_load/test_fast_load.py
+++ b/lib/iris/tests/integration/fast_load/test_fast_load.py
@@ -205,7 +205,6 @@ class Mixin_FieldTest(object):
             # we must include a STASH attribute.
             cube.attributes['STASH'] = STASH.from_msi(stash)
             cube.fill_value = np.float32(-1e30)
-            cube.dtype = np.dtype('float32')
 
         # Add x and y coords.
         cs = GeogCS(EARTH_RADIUS)

--- a/lib/iris/tests/test_concatenate.py
+++ b/lib/iris/tests/test_concatenate.py
@@ -31,12 +31,13 @@ import numpy.ma as ma
 
 import iris.cube
 from iris.coords import DimCoord, AuxCoord
+from iris._lazy_data import as_lazy_data
 import iris.tests.stock as stock
 
 
 def _make_cube(x, y, data, aux=None, offset=0, scalar=None,
                dtype=np.dtype('float32'), fill_value=None,
-               mask=None):
+               mask=None, lazy=False):
     """
     A convenience test function that creates a custom 2D cube.
 
@@ -92,7 +93,11 @@ def _make_cube(x, y, data, aux=None, offset=0, scalar=None,
     else:
         cube_data = np.empty(shape, dtype=dtype)
         cube_data[:] = data
-    cube = iris.cube.Cube(cube_data, fill_value=fill_value)
+
+    if lazy:
+        cube_data = as_lazy_data(cube_data)
+
+    cube = iris.cube.Cube(cube_data, fill_value=fill_value, dtype=dtype)
     coord = DimCoord(y_range, long_name='y')
     coord.guess_bounds()
     cube.add_dim_coord(coord, 0)
@@ -468,9 +473,7 @@ class Test2D(tests.IrisTest):
                           mask=mask)
         cubes.append(cube)
         mask = [(0, 1), (1, 0)]
-        cube = _make_cube(x, (2, 4), 2, dtype=dtype, mask=mask)
-        cube.data = cube.lazy_data()
-        cube.dtype = dtype
+        cube = _make_cube(x, (2, 4), 2, dtype=dtype, mask=mask, lazy=True)
         cube.fill_value = fill_value
         cubes.append(cube)
         result = concatenate(cubes)
@@ -489,9 +492,7 @@ class Test2D(tests.IrisTest):
         dtype = np.dtype('int16')
         fill_value = -37
         mask = [(0, 1), (1, 0)]
-        cube = _make_cube(x, (2, 4), 2, dtype=dtype, mask=mask)
-        cube.data = cube.lazy_data()
-        cube.dtype = dtype
+        cube = _make_cube(x, (2, 4), 2, dtype=dtype, mask=mask, lazy=True)
         cube.fill_value = fill_value
         cubes.append(cube)
         mask = [(0, 1), (0, 1)]

--- a/lib/iris/tests/unit/cube/test_Cube.py
+++ b/lib/iris/tests/unit/cube/test_Cube.py
@@ -1312,12 +1312,6 @@ class Test_data_dtype_fillvalue(tests.IrisTest):
         self.assertEqual(cube.dtype, np.dtype('f8'))
         self.assertIsNone(cube.fill_value)
 
-    def test_realdata_dtype_change(self):
-        # Check that cannot change real data dtype.
-        cube = self._sample_cube()
-        with self.assertRaisesRegexp(ValueError, "cannot set dtype"):
-            cube.dtype = np.dtype('i8')
-
     def test_lazydata_nonmaskedints(self):
         # Check that lazy ints retain their dtype.
         data_original = self._sample_data(dtype=np.int32)
@@ -1332,44 +1326,12 @@ class Test_data_dtype_fillvalue(tests.IrisTest):
         # Check that lazy masked ints have a modified dtype.
         masked_data_original = self._sample_data(dtype=np.int32, masked=True)
         masked_data_lazy = as_lazy_data(masked_data_original)
-        cube = Cube(masked_data_lazy)
-        cube.dtype = masked_data_original.dtype
+        cube = Cube(masked_data_lazy, dtype=masked_data_original.dtype)
         self.assertEqual(cube.dtype, np.dtype('i4'))
         self.assertEqual(cube.core_data.dtype, np.dtype('f8'))
         data = cube.data
         self.assertTrue(np.ma.is_masked(data))
         self.assertMaskedArrayEqual(data, masked_data_original)
-
-    def test_lazydata_floating_dtype_change(self):
-        # Check that re-assigning dtype won't allow a floating type.
-        cube = self._sample_cube(dtype=np.float32, lazy=True,
-                                 cube_fill_value=23.7)
-        self.assertArrayAllClose(cube.fill_value, 23.7)
-        msg = "Can only cast lazy data to integral dtype"
-        with self.assertRaisesRegexp(ValueError, msg):
-            cube.dtype = np.float64
-
-    def test_lazydata_dtype_change(self):
-        # Check that re-assigning dtype resets fill_value.
-        cube = self._sample_cube(dtype=np.float32, lazy=True,
-                                 cube_fill_value=23.7)
-        self.assertArrayAllClose(cube.fill_value, 23.7)
-        cube.dtype = np.int16
-        self.assertEqual(cube.dtype, np.dtype('i2'))
-        self.assertEqual(cube.core_data.dtype, np.dtype('f4'))
-        self.assertIsNone(cube.fill_value)
-
-    def test_lazydata_maskedints_dtype_change(self):
-        # Check that re-assigning dtype resets fill_value.
-        cube = self._sample_cube(dtype=np.int16, masked=True, lazy=True,
-                                 cube_fill_value=199)
-        self.assertEqual(cube.dtype, np.dtype('i2'))
-        self.assertEqual(cube.core_data.dtype, np.dtype('f8'))
-        self.assertArrayAllClose(cube.fill_value, 199)
-        cube.dtype = np.int64
-        self.assertEqual(cube.dtype, np.dtype('i8'))
-        self.assertEqual(cube.core_data.dtype, np.dtype('f8'))
-        self.assertIsNone(cube.fill_value)
 
     def test_fill_value__int_dtype_to_float(self):
         # Check that fill_value is cast to dtype, e.g. float --> int.


### PR DESCRIPTION
Shows how we might avoid setting cube.dtype **at all**.

Can still pass dtype= to creation, but cannot subsequently change it.
This means you can't do all that creation can do, when you use the form `cube.data=lazy_data`.
However, I think you can always copy the cube instead.

**Not currently viable** as it needs merging with later changes...
Also, I think some problems are still left unresolved here ?