### PR TITLE
netcdf save rehash : beginnings of append support

### DIFF
--- a/lib/iris/fileformats/netcdf.py
+++ b/lib/iris/fileformats/netcdf.py
@@ -1095,8 +1095,12 @@ class Saver(object):
         import subprocess
         import sys
         cmd = 'ncdump -h ' + output_path
-        lines = subprocess.check_output(cmd, shell=True)
-        lines = lines.split('\n')
+        chars = subprocess.check_output(cmd, shell=True)
+        # Convert bytes into strings in Python 2/3 compatible way.
+        if (not isinstance(chars, six.string_types) and
+                hasattr(chars, 'decode')):
+            chars = chars.decode()
+        lines = chars.split('\n')
         lines = ['netcdf [[XXX]] {'] + \
             lines[1:]  # replace first with filepath
         outlines = ['',


### PR DESCRIPTION
WIP : **DO NOT MERGE**
Post-refactor (#51) code, beginning work on implementing a netcdf-append strategy

Status: highly preliminary (!) : 
 * the `_offset_keys` routine may not now be necessary
   see http://docs.dask.org/en/latest/array-api.html#dask.array.store
   -- use of the `regions` key may be able to replace this.
 * the actual "append" operation is really very simple ...
 * ***BUT*** the 'validity checking' code in the `_prepare_append` method is huge + still untested
   **it has become a monster !!**
 * the 'netcdf data representation' classes introduced in #51 now  look doubtful to me
   * use of '_SlotsHolder' may be excessive : simpler to define classes directly ?
   * ***or*** replace with xarray objects (???)
 * the use of attached "tracking" properties in the 'label_links' routine (inner routine to `_prepare_append`) seems inappropriate
    - almost certainly clearer to store relational info in separate mapping objects (and maybe even simpler)
