### PR TITLE
Rework "context" interface

### DIFF
--- a/lib/iris/common/lenient.py
+++ b/lib/iris/common/lenient.py
@@ -214,7 +214,7 @@ def qualname(func):
     if callable(func):
         module = getmodule(func)
         result = f"{module.__name__}.{func.__qualname__}"
-
+        result = result.replace(".", "_x_")
     return result
 
 

--- a/lib/iris/common/lenient.py
+++ b/lib/iris/common/lenient.py
@@ -374,7 +374,7 @@ class Lenient(threading.local):
             self[name] = value
 
         # Get the active client.
-        active = self.__dict__["active"]
+        active = self.active
 
         if args:
             # Update the client with the provided services.
@@ -386,13 +386,10 @@ class Lenient(threading.local):
                 # as this causes a namespace clash with this method
                 # i.e., Lenient.context, via Lenient.__getattr__
                 active = "__context"
-                self.__dict__["active"] = active
-                #                 self.__dict__[active] = new_services
-                update_client(active, new_services)
+                self.active = active
 
-            else:
-                # Append provided services to any pre-existing services of the active client.
-                update_client(active, new_services)
+            update_client(active, new_services)
+
         else:
             # Append previous ephemeral services (for non-specific client) to the active client.
             if (
@@ -400,7 +397,7 @@ class Lenient(threading.local):
                 and active != "__context"
                 and "__context" in self.__dict__
             ):
-                new_services = self.__dict__["__context"]
+                new_services = self.__context
                 update_client(active, new_services)
 
         try:

--- a/lib/iris/tests/unit/common/lenient/test_Lenient.py
+++ b/lib/iris/tests/unit/common/lenient/test_Lenient.py
@@ -564,7 +564,7 @@ class Test_context(tests.IrisTest):
             dict(active=client, client=set((svc, True) for svc in services))
         )
         self.assertEqual(context["active"], expected["active"])
-        self.assertEqual(set(context["client"]), set(expected["client"]))
+        self.assertEqual(context["client"], expected["client"])
         self.assertEqual(post, self.default)
 
     def test_args_callable(self):
@@ -590,7 +590,7 @@ class Test_context(tests.IrisTest):
             )
         )
         self.assertEqual(context["active"], expected["active"])
-        self.assertEqual(set(context["client"]), set(expected["client"]))
+        self.assertEqual(context["client"], expected["client"])
         self.assertEqual(post, self.default)
 
     def test_context_runtime(self):

--- a/lib/iris/tests/unit/common/lenient/test_Lenient.py
+++ b/lib/iris/tests/unit/common/lenient/test_Lenient.py
@@ -538,6 +538,21 @@ class Test_context(tests.IrisTest):
         self.assertEqual(context, expected)
         self.assertEqual(post, self.default)
 
+    #     def test_kwargs(self):
+    #         client = "client"
+    #         self.lenient.__dict__["service1"] = False
+    #         self.lenient.__dict__["service2"] = False
+    #         pre = self.copy()
+    #         with self.lenient.context(active=client, service1=True, service2=True):
+    #             context = self.copy()
+    #         post = self.copy()
+    #         self.default.update(dict(service1=False, service2=False))
+    #         self.assertEqual(pre, self.default)
+    #         expected = self.default.copy()
+    #         expected.update(dict(active=client, service1=True, service2=True))
+    #         self.assertEqual(context, expected)
+    #         self.assertEqual(post, self.default)
+
     def test_args_str(self):
         client = "client"
         services = ("service1", "service2")

--- a/lib/iris/tests/unit/common/lenient/test_Lenient.py
+++ b/lib/iris/tests/unit/common/lenient/test_Lenient.py
@@ -536,131 +536,11 @@ class Test_context(tests.IrisTest):
         self.assertEqual(context, expected)
         self.assertEqual(post, self.default)
 
-    def test_kwargs(self):
-        client = "client"
-        self.lenient.__dict__["service1"] = False
-        self.lenient.__dict__["service2"] = False
-        pre = self.copy()
-        with self.lenient.context(active=client, service1=True, service2=True):
-            context = self.copy()
-        post = self.copy()
-        self.default.update(dict(service1=False, service2=False))
-        self.assertEqual(pre, self.default)
-        expected = self.default.copy()
-        expected.update(dict(active=client, service1=True, service2=True))
-        self.assertEqual(context, expected)
-        self.assertEqual(post, self.default)
-
     def test_args_str(self):
         client = "client"
         services = ("service1", "service2")
         pre = self.copy()
-        with self.lenient.context(*services, active=client):
-            context = self.copy()
-        post = self.copy()
-        self.assertEqual(pre, self.default)
-        expected = self.default.copy()
-        expected.update(
-            dict(active=client, client=set((svc, True) for svc in services))
-        )
-        self.assertEqual(context["active"], expected["active"])
-        self.assertEqual(context["client"], expected["client"])
-        self.assertEqual(post, self.default)
-
-    def test_args_callable(self):
-        def service1():
-            pass
-
-        def service2():
-            pass
-
-        client = "client"
-        services = (service1, service2)
-        pre = self.copy()
-        with self.lenient.context(*services, active=client):
-            context = self.copy()
-        post = self.copy()
-        qualname_services = tuple([qualname(service) for service in services])
-        self.assertEqual(pre, self.default)
-        expected = self.default.copy()
-        expected.update(
-            dict(
-                active=client,
-                client=set((svc, True) for svc in qualname_services),
-            )
-        )
-        self.assertEqual(context["active"], expected["active"])
-        self.assertEqual(context["client"], expected["client"])
-        self.assertEqual(post, self.default)
-
-    def test_context_runtime(self):
-        services = ("service1", "service2")
-        pre = self.copy()
-        with self.lenient.context(*services):
-            context = self.copy()
-        post = self.copy()
-        self.assertEqual(pre, self.default)
-        expected = self.default.copy()
-        expected.update(
-            dict(
-                active="__context",
-                __context=set([(srv, True) for srv in services]),
-            )
-        )
-        self.assertEqual(context, expected)
-        self.assertEqual(post, self.default)
-
-
-class Test_context2__oldstyles(tests.IrisTest):
-    def setUp(self):
-        self.lenient = Lenient()
-        self.default = dict(active=None, enable=LENIENT_ENABLE_DEFAULT)
-
-    def copy(self):
-        return self.lenient.__dict__.copy()
-
-    def test_nop(self):
-        pre = self.copy()
-        with self.lenient.context2():
-            context = self.copy()
-        post = self.copy()
-        self.assertEqual(pre, self.default)
-        self.assertEqual(context, self.default)
-        self.assertEqual(post, self.default)
-
-    def test_active_str(self):
-        client = "client"
-        pre = self.copy()
-        with self.lenient.context2(active=client):
-            context = self.copy()
-        post = self.copy()
-        self.assertEqual(pre, self.default)
-        expected = self.default.copy()
-        expected.update(dict(active=client))
-        self.assertEqual(context, expected)
-        self.assertEqual(post, self.default)
-
-    def test_active_callable(self):
-        def client():
-            pass
-
-        pre = self.copy()
-        with self.lenient.context2(active=client):
-            context = self.copy()
-        post = self.copy()
-        qualname_client = qualname(client)
-        self.assertEqual(pre, self.default)
-        expected = self.default.copy()
-        expected.update(dict(active=qualname_client))
-        self.assertEqual(context, expected)
-        self.assertEqual(post, self.default)
-
-    def test_args_str(self):
-        client = "client"
-        services = ("service1", "service2")
-        pre = self.copy()
-        # ref: self.lenient.context(*services, active=client):
-        with self.lenient.context2(client, services=services):
+        with self.lenient.context(client, services=services):
             context = self.copy()
         post = self.copy()
         self.assertEqual(pre, self.default)
@@ -682,8 +562,7 @@ class Test_context2__oldstyles(tests.IrisTest):
         client = "client"
         services = (service1, service2)
         pre = self.copy()
-        # ref: self.lenient.context(*services, active=client):
-        with self.lenient.context2(client, services=services):
+        with self.lenient.context(client, services=services):
             context = self.copy()
         post = self.copy()
         qualname_services = tuple([qualname(service) for service in services])
@@ -702,8 +581,7 @@ class Test_context2__oldstyles(tests.IrisTest):
     def test_context_runtime(self):
         services = ("service1", "service2")
         pre = self.copy()
-        # ref: self.lenient.context(*services):
-        with self.lenient.context2(services=services):
+        with self.lenient.context(services=services):
             context = self.copy()
         post = self.copy()
         self.assertEqual(pre, self.default)
@@ -730,8 +608,7 @@ class Test_context2__newstyles(tests.IrisTest):
         client = "client"
         services = ("service1", "service2")
         pre = self.copy()
-        # ref: self.lenient.context(*services, active=client):
-        with self.lenient.context2(client, service1=True, service2=True):
+        with self.lenient.context(client, service1=True, service2=True):
             context = self.copy()
         post = self.copy()
         self.assertEqual(pre, self.default)
@@ -753,8 +630,7 @@ class Test_context2__newstyles(tests.IrisTest):
         client = "client"
         service_qualnames = [qualname(svc) for svc in (service1, service2)]
         pre = self.copy()
-        # ref: self.lenient.context(*services, active=client):
-        with self.lenient.context2(
+        with self.lenient.context(
             client, **{name: True for name in service_qualnames}
         ):
             context = self.copy()
@@ -774,8 +650,7 @@ class Test_context2__newstyles(tests.IrisTest):
     def test_context_runtime(self):
         services = ("service1", "service2")
         pre = self.copy()
-        # ref: self.lenient.context(*services):
-        with self.lenient.context2(services=services):
+        with self.lenient.context(services=services):
             context = self.copy()
         post = self.copy()
         self.assertEqual(pre, self.default)
@@ -802,8 +677,7 @@ class Test_context2__newstyles(tests.IrisTest):
         # Note: make dict for keywords, as the names are really long !
         settings = {qualname1: True, qualname2: False}
 
-        # ref: self.lenient.context(*services, active=client):
-        with self.lenient.context2("client", **settings):
+        with self.lenient.context("client", **settings):
             context = self.copy()
         post = self.copy()
         self.assertEqual(pre, self.default)
@@ -821,10 +695,9 @@ class Test_context2__newstyles(tests.IrisTest):
     def test_args_modify(self):
         pre = self.copy()
 
-        # ref: self.lenient.context(*services, active=client):
-        with self.lenient.context2("client", set1=1, set2=2):
+        with self.lenient.context("client", set1=1, set2=2):
             context1 = self.copy()
-            with self.lenient.context2(
+            with self.lenient.context(
                 "client", set2="not two", modify_existing=True
             ):
                 context2 = self.copy()

--- a/lib/iris/tests/unit/common/lenient/test_lenient_client.py
+++ b/lib/iris/tests/unit/common/lenient/test_lenient_client.py
@@ -21,8 +21,9 @@ from iris.common.lenient import LENIENT, lenient_client
 class Test(tests.IrisTest):
     def setUp(self):
         module_name = getmodule(self).__name__
-        self.client = f"{module_name}" + ".Test.{}.<locals>.myclient"
-        self.service = f"{module_name}" + ".Test.{}.<locals>.myservice"
+        module_name = module_name.replace(".", "_x_")
+        self.client = f"{module_name}" + "_x_Test_x_{}_x_<locals>_x_myclient"
+        self.service = f"{module_name}" + "_x_Test_x_{}_x_<locals>_x_myservice"
         self.active = "active"
         self.args_in = sentinel.arg1, sentinel.arg2
         self.kwargs_in = dict(kwarg1=sentinel.kwarg1, kwarg2=sentinel.kwarg2)

--- a/lib/iris/tests/unit/common/lenient/test_lenient_client.py
+++ b/lib/iris/tests/unit/common/lenient/test_lenient_client.py
@@ -129,7 +129,7 @@ class Test(tests.IrisTest):
         qualname_client = self.client.format("test_call_kwargs_single")
         self.assertEqual(result[self.active], qualname_client)
         self.assertIn(qualname_client, result)
-        self.assertEqual(result[qualname_client], (service,))
+        self.assertEqual(result[qualname_client], set([(service, True)]))
 
     def test_call_kwargs_single_callable(self):
         def myservice():
@@ -145,8 +145,10 @@ class Test(tests.IrisTest):
         qualname_client = self.client.format(test_name)
         self.assertEqual(result[self.active], qualname_client)
         self.assertIn(qualname_client, result)
-        qualname_services = (self.service.format(test_name),)
-        self.assertEqual(result[qualname_client], qualname_services)
+        qualname_service = self.service.format(test_name)
+        self.assertEqual(
+            result[qualname_client], set([(qualname_service, True)])
+        )
 
     def test_call_kwargs_iterable(self):
         services = (sentinel.service1, sentinel.service2)
@@ -160,7 +162,9 @@ class Test(tests.IrisTest):
         qualname_client = self.client.format("test_call_kwargs_iterable")
         self.assertEqual(result[self.active], qualname_client)
         self.assertIn(qualname_client, result)
-        self.assertEqual(set(result[qualname_client]), set(services))
+        self.assertEqual(
+            result[qualname_client], set((svc, True) for svc in services)
+        )
 
     def test_call_client_args_kwargs(self):
         @lenient_client()

--- a/lib/iris/tests/unit/common/lenient/test_lenient_service.py
+++ b/lib/iris/tests/unit/common/lenient/test_lenient_service.py
@@ -21,7 +21,8 @@ from iris.common.lenient import LENIENT, lenient_service
 class Test(tests.IrisTest):
     def setUp(self):
         module_name = getmodule(self).__name__
-        self.service = f"{module_name}" + ".Test.{}.<locals>.myservice"
+        module_name = module_name.replace(".", "_x_")
+        self.service = f"{module_name}" + "_x_Test_x_{}_x_<locals>_x_myservice"
         self.args_in = sentinel.arg1, sentinel.arg2
         self.kwargs_in = dict(kwarg1=sentinel.kwarg1, kwarg2=sentinel.kwarg2)
 

--- a/lib/iris/tests/unit/common/lenient/test_qualname.py
+++ b/lib/iris/tests/unit/common/lenient/test_qualname.py
@@ -21,7 +21,8 @@ from iris.common.lenient import qualname
 class Test(tests.IrisTest):
     def setUp(self):
         module_name = getmodule(self).__name__
-        self.locals = f"{module_name}" + ".Test.{}.<locals>.{}"
+        module_name = module_name.replace(".", "_x_")
+        self.locals = f"{module_name}" + "_x_Test_x_{}_x_<locals>_x_{}"
 
     def test_pass_thru_non_callable(self):
         func = sentinel.func
@@ -42,7 +43,7 @@ class Test(tests.IrisTest):
         import iris
 
         result = qualname(iris.load)
-        self.assertEqual(result, "iris.load")
+        self.assertEqual(result, "iris_x_load")
 
     def test_callable_method_local(self):
         class MyClass:
@@ -50,7 +51,7 @@ class Test(tests.IrisTest):
                 pass
 
         qualname_method = self.locals.format(
-            "test_callable_method_local", "MyClass.mymethod"
+            "test_callable_method_local", "MyClass_x_mymethod"
         )
         result = qualname(MyClass.mymethod)
         self.assertEqual(result, qualname_method)
@@ -59,7 +60,7 @@ class Test(tests.IrisTest):
         import iris
 
         result = qualname(iris.cube.Cube.add_ancillary_variable)
-        self.assertEqual(result, "iris.cube.Cube.add_ancillary_variable")
+        self.assertEqual(result, "iris_x_cube_x_Cube_x_add_ancillary_variable")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Modified to allow settings updates to accommodate non-binary settings values, and making the service names valid as keywords.
This means you can create an (inner) context in which a existing binary-type service is turned "off".
It also supports client value settings with "service_name=control_value"

So, this replaces `context(*services, active=client)` with `context(client, services)`
But it also allows :
  * legacy arg form `services (list of callable or name)` still works. Now equivalent to `{svc:True for svc in services}`
  * but services can now also be assigned a 'setting value', rather than just "turned on"
  * `**kwargs` form allows e.g. `context(svc1=True, svc2=True)` as alternative to `context(services=(svc1, svc2)`
     - plus of course, the assignment values could now be ~anything (?hashable?)
  * "services" arg can be iterable or dict, so `context(client, **services_dict)` is same as `context(client, services_dict)`

Own review [below](https://github.com/pp-mo/iris/pull/62#pullrequestreview-440717523) illustrates the key changes by highlighting the modified `context` usages in `tests/unit/common/lenient/test_Lenient.py`

TODO: probably more tests for the new stuff

***BIG NOTE:***
For this, I have re-implemented the basic settings in the `Lenient.__dict__`, replacing tuples of names with a set of (key, value) pairs.
However, I only did this because I wasn't clear why a tuple is used at present
  -- whether for efficiency or so it is hashable.
  -- the existing comments do make clear that order is not supposed to matter.
If these factors are not essential, it would still be *much nicer to just use dictionaries*.
This was all a bit of a pain with the tests, because they all work via implementation details (checking the dict) instead of some public access 😓  
But it could be changed again if needed, without too much grief  ... Really.  Dictionaries would definitely be more natural.