### PR TITLE
Beginnings of better logging tests.

### DIFF
--- a/lib/iris/experimental/ugrid/__init__.py
+++ b/lib/iris/experimental/ugrid/__init__.py
@@ -1229,7 +1229,7 @@ class Mesh(CFVariableMixin):
                     "Not setting face_dimension (inappropriate for "
                     f"topology_dimension={self.topology_dimension} ."
                 )
-                logger.debug(message)
+                logger.debug(message, extra=dict(cls=None))
         elif not name or not isinstance(name, str):
             face_dimension = f"Mesh{self.topology_dimension}d_face"
         else:

--- a/lib/iris/tests/unit/experimental/ugrid/test_Mesh.py
+++ b/lib/iris/tests/unit/experimental/ugrid/test_Mesh.py
@@ -725,6 +725,8 @@ class TestOperations1D(TestMeshCommon):
         default = ugrid.Mesh1DNames("Mesh1d_node", "Mesh1d_edge")
         self.assertEqual(default, self.mesh.dimension_names())
 
+        ugrid.logger.setLevel("DEBUG")
+        self.mesh.dimension_names("foo", "bar", "baz")
         with self.assertLogs(ugrid.logger, level="DEBUG") as log:
             self.mesh.dimension_names("foo", "bar", "baz")
             self.assertIn("Not setting face_dimension", log.output[0])
@@ -746,6 +748,8 @@ class TestOperations1D(TestMeshCommon):
         self.assertEqual("foo", self.mesh.edge_dimension)
 
     def test_face_dimension_set(self):
+        # ugrid.logger.setLevel('DEBUG')
+        # self.mesh.face_dimension = "foo"
         with self.assertLogs(ugrid.logger, level="DEBUG") as log:
             self.mesh.face_dimension = "foo"
             self.assertIn("Not setting face_dimension", log.output[0])


### PR DESCRIPTION
Extends the standard `unittest.TestCase.assertLogs` method to also exercise the formatting for the messages.

This was in response to problems in Iris testing, see : https://github.com/SciTools/iris/pull/4106

The key problem is that using `assertLogs` doesn't actually do what the 'real' loggin operation does, so misses code coverage and possible bugs.
I'm still not really convinced that this covers _everything_ that might go wrong in the 'real' logging operation, but I think that it at least helps.  It seems that the 'extra format' is perhaps the main configurable part of logger operation, and this exercises the formatter code.  What meanwhile might go wrong with any of the attached _handlers_ is not quite so clear : we still aren't exercising those, but if run they would write to files / terminal etc, which we don't want within testing.